### PR TITLE
Support analyzer v8 and source_gen v4

### DIFF
--- a/packages/analyzer_buffer/CHANGELOG.md
+++ b/packages/analyzer_buffer/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.11 - 2025-09-07
 
 Updated dependencies to support analyzer v8
-This allows for compatibility with upgraded generators using analyzer v8, source_gen v4, and even build v4
+This allows for compatibility with upgraded generators using analyzer v8 and source_gen v4
   (thanks to @TekExplorer)
 
 - `analyzer: '>=7.3.0 <9.0.0'`

--- a/packages/analyzer_buffer/CHANGELOG.md
+++ b/packages/analyzer_buffer/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.11 - 2025-09-07
+
+Updated dependencies to support analyzer v8
+This allows for compatibility with upgraded generators using analyzer v8, source_gen v4, and even build v4
+  (thanks to @TekExplorer)
+
+- `analyzer: '>=7.3.0 <9.0.0'`
+- `source_gen: '>=3.0.0 <5.0.0'`
+
 ## 0.1.10 - 2025-08-26
 
 - Fix some issue with `functionType.toCode` not including `required`

--- a/packages/analyzer_buffer/pubspec.yaml
+++ b/packages/analyzer_buffer/pubspec.yaml
@@ -1,5 +1,5 @@
 name: analyzer_buffer
-version: 0.1.10
+version: 0.1.11
 description: A package to help writing code-generators while supporting import prefixes and default values
 repository: https://github.com/rrousselGit/analyzer_buffer
 
@@ -9,11 +9,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^7.3.0
+  analyzer: '>=7.3.0 <9.0.0'
   collection: ^1.19.1
   meta: ^1.15.0
   path: ^1.9.1
-  source_gen: ^3.0.0
+  source_gen: '>=3.0.0 <5.0.0'
 
 dev_dependencies:
   test: ^1.25.15

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -8,16 +8,16 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ">=6.9.0 <8.0.0"
+  analyzer: ">=7.3.0 <9.0.0"
   analyzer_buffer: ^0.1.5
-  build: ^3.0.0
+  build: '>=3.0.0 <5.0.0'
   build_config: ^1.1.0
   collection: ^1.15.0
   flutter:
     sdk: flutter
   meta: ^1.16.0
   path: ^1.9.1
-  source_gen: ^3.0.0
+  source_gen: '>=3.0.0 <5.0.0'
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
fixes #4

Expanded the analyzer and source_gen dependencies to the next major versions.

My testing indicates it works fine so far.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a 0.1.11 changelog entry noting compatibility with newer analyzer (v8) and source_gen (v4), with acknowledgments.

* **Chores**
  * Bumped analyzer_buffer package version to 0.1.11.
  * Broadened dependency ranges to support newer releases:
    * analyzer: >=7.3.0 <9.0.0
    * source_gen: >=3.0.0 <5.0.0
    * build (e2e): >=3.0.0 <5.0.0
  * No functional or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->